### PR TITLE
Support partial payments with outstanding tracking

### DIFF
--- a/src/main/java/com/servease/demo/dto/response/ActiveOrderResponse.java
+++ b/src/main/java/com/servease/demo/dto/response/ActiveOrderResponse.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 public class ActiveOrderResponse {
     private Long orderId;
     private Integer totalPrice;
+    private Integer paidAmount;
+    private Integer outstandingAmount;
     private List<OrderItemSummaryResponse> orderItems;
 
     public static ActiveOrderResponse fromEntity(Order order) {
@@ -21,6 +23,8 @@ public class ActiveOrderResponse {
         return ActiveOrderResponse.builder()
                 .orderId(order.getId())
                 .totalPrice(order.getTotalPrice())
+                .paidAmount(order.getPaidAmount())
+                .outstandingAmount(order.getOutstandingAmount())
                 .orderItems(order.getOrderItems().stream()
                         .map(OrderItemSummaryResponse::fromEntity)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/servease/demo/dto/response/OrderResponse.java
+++ b/src/main/java/com/servease/demo/dto/response/OrderResponse.java
@@ -20,6 +20,8 @@ public class OrderResponse {
     private Long restaurantTableId;
     private OrderStatus status;
     private int totalPrice;
+    private int paidAmount;
+    private int outstandingAmount;
     private boolean isPaid;
     private LocalDateTime orderTime;
     private List<OrderItemResponse> orderItems;
@@ -41,6 +43,8 @@ public class OrderResponse {
                 .restaurantTableId(order.getRestaurantTable().getId())
                 .status(order.getStatus())
                 .totalPrice(order.getTotalPrice())
+                .paidAmount(order.getPaidAmount())
+                .outstandingAmount(order.getOutstandingAmount())
                 .isPaid(order.isPaid())
                 .orderTime(order.getOrderTime())
                 .orderItems(itemResponses)

--- a/src/main/java/com/servease/demo/dto/response/RestaurantTableResponse.java
+++ b/src/main/java/com/servease/demo/dto/response/RestaurantTableResponse.java
@@ -30,7 +30,7 @@ public class RestaurantTableResponse {
 
         if (activeOrderOpt.isPresent()) {
             Order activeOrder = activeOrderOpt.get();
-            status = activeOrderOpt.get().getStatus().name();// "ORDERED" or "SERVED"
+            status = resolveDisplayStatus(activeOrder);
             activeOrderResponse = ActiveOrderResponse.fromEntity(activeOrder);
         } else {
             status = "EMPTY";
@@ -55,7 +55,7 @@ public class RestaurantTableResponse {
         ActiveOrderResponse activeOrderResponse = null;
 
         if (latestActiveOrder != null) {
-            status = latestActiveOrder.getStatus().name(); // "ORDERED" or "SERVED"
+            status = resolveDisplayStatus(latestActiveOrder); // "ORDERED" or "SERVED"
             activeOrderResponse = ActiveOrderResponse.fromEntity(latestActiveOrder);
         } else {
             status = "EMPTY";
@@ -69,5 +69,19 @@ public class RestaurantTableResponse {
                 .build();
     }
 
-// ... (기존 fromEntity 메서드)
+    private static String resolveDisplayStatus(Order order) {
+        if (order == null) {
+            return "EMPTY";
+        }
+
+        if (order.isPaid()) {
+            return order.getStatus().name();
+        }
+
+        if (order.getPaidAmount() != null && order.getPaidAmount() > 0) {
+            return "PARTIALLY_PAID";
+        }
+
+        return order.getStatus().name();
+    }
 }

--- a/src/main/java/com/servease/demo/global/exception/ErrorCode.java
+++ b/src/main/java/com/servease/demo/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     TABLES_NOT_EMPTY(HttpStatus.CONFLICT, "E018", "모든 테이블이 'EMPTY' 상태일 때만 테이블 수를 변경할 수 있습니다."),
     DUPLICATE_ORDER_ID(HttpStatus.CONFLICT, "E019", "중복된 orderId입니다."),
     AMOUNT_NOT_MATCH(HttpStatus.CONFLICT,"E021","주문 금액과 결제 금액이 일치하지 않습니다." ),
+    PAYMENT_AMOUNT_EXCEEDS_OUTSTANDING(HttpStatus.CONFLICT, "E025", "결제 금액이 잔여 금액을 초과했습니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "E023", "이미 가입된 휴대폰 번호입니다."),
 
 

--- a/src/main/java/com/servease/demo/model/entity/Order.java
+++ b/src/main/java/com/servease/demo/model/entity/Order.java
@@ -41,6 +41,10 @@ public class Order {
     @Column(name = "total_price", nullable = false)
     private Integer totalPrice;
 
+    @Builder.Default
+    @Column(name = "paid_amount", nullable = false)
+    private Integer paidAmount = 0;
+
     @Column(name = "is_paid", nullable = false)
     private boolean isPaid = false;
 
@@ -70,6 +74,17 @@ public class Order {
         this.totalPrice = this.orderItems.stream()
                 .mapToInt(item -> item.getQuantity() * item.getItemPrice())
                 .sum();
+    }
+
+    public void increasePaidAmount(int amount) {
+        this.paidAmount += amount;
+    }
+
+    public int getOutstandingAmount() {
+        if (this.totalPrice == null) {
+            return 0;
+        }
+        return Math.max(this.totalPrice - this.paidAmount, 0);
     }
 
     public void removeItemById(Long orderItemId){

--- a/src/main/java/com/servease/demo/model/entity/Payment.java
+++ b/src/main/java/com/servease/demo/model/entity/Payment.java
@@ -13,7 +13,7 @@ import java.time.OffsetDateTime;
 @Table(name = "payments",
         indexes = {
                 @Index(name = "ux_payments_payment_key", columnList = "payment_key", unique = true),
-                @Index(name = "ux_payments_order_id", columnList = "order_id", unique = true),
+                @Index(name = "ix_payments_order_id", columnList = "order_id"),
                 @Index(name = "ix_payments_created_at", columnList = "created_at")
         }
 )


### PR DESCRIPTION
## Summary
- track paid and outstanding amounts on orders and expose them via API responses
- allow multiple payments per order while validating outstanding balances and preventing overpayment
- surface partial payment state in restaurant table responses and update error handling
- automatically finalize served orders when their outstanding balance reaches zero

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee030b1d5083259b4a6556c4f4ec61